### PR TITLE
Removed PieMenu as conflict from package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -28,7 +28,6 @@
       <depend optional="False" type="python">pyqtribbon</depend>
       <depend optional="False" type="python">qtpy</depend>
       <depend optional="True" type="python">keyboard</depend>
-      <conflict>PieMenu</conflict>
       <subdirectory>./</subdirectory>
     </workbench>
   </content>


### PR DESCRIPTION
PieMenu is not compatible with the latest dev version of FreeCAD